### PR TITLE
 Solving the problem that ES6 class can not be loaded in view

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,10 @@ function renderComponents (states, onremovers) {
     var node
     if (component.tag.view) {
       node = component.tag.view(component)
-    } if (isFunction(component.tag)) {
+    }
+    if (component.tag.prototype != null && typeof component.tag.prototype.view === 'function') {
+      node = (new component.tag(component)).view(component) // eslint-disable-line new-cap
+    } else if (isFunction(component.tag)) {
       node = component.tag(component).view(component)
     }
     if (node) {

--- a/test.js
+++ b/test.js
@@ -585,3 +585,15 @@ describe('Exposing vnode', function () {
     expect(out.vnode.state.baz).toEqual('foz')
   })
 })
+
+describe('Components created with ES6 Classes', function () {
+  it('should call component view method', function () {
+    class Foo {
+      view () {
+        return m('.bar')
+      }
+    }
+
+    mq(m('.foo', m(Foo))).should.have('.foo .bar')
+  })
+})


### PR DESCRIPTION
I ran the following code.

```javascript
describe('Components created with ES6 Class', function () {
  it('should call component view method', function () {
    class Foo {
      view () {
        return m('.bar')
      }
    }

    mq(m('.foo', m(Foo))).should.have('.foo .bar')
  })
})
```

I encountered the following error.

```shell
TypeError: Class constructor Foo cannot be invoked without 'new'
```

If it is the same problem as #80 , we will close this.