### PR TITLE
Make renderComponent respect key

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,8 @@ function renderComponents (states, instances, onremovers) {
       })
     }
     if (isComponent(node.tag)) {
-      return renderNode(renderComponent(node, treePath), treePath + PD + (node.key || ''))
+      var componentTreePath = treePath + PD + (node.key || '')
+      return renderNode(renderComponent(node, componentTreePath), componentTreePath)
     }
     if (node.children) {
       node.renderedChildren = renderNode(node.children, treePath + PD + (node.key || ''))

--- a/test.js
+++ b/test.js
@@ -781,3 +781,30 @@ describe('Exposing vnode', function () {
     expect(out.vnode.state.baz).toEqual('foz')
   })
 })
+
+describe('keys', function () {
+  it('should distinguish components with different keys', function () {
+    var firstComponent = {
+      view: function () {
+        return m('.first')
+      }
+    }
+    var secondComponent = {
+      view: function () {
+        return m('.second')
+      }
+    }
+    var i = 0
+    var rootComponent = {
+      view: function () {
+        return m(i === 0 ? firstComponent : secondComponent, {key: i})
+      }
+    }
+    var out = mq(rootComponent)
+    out.should.have('.first')
+
+    i = 1
+    out.redraw()
+    out.should.have('.second')
+  })
+})


### PR DESCRIPTION
When redraw is called and a component with a key has been replaced by a different component with a different key, mithril-query doesn't render the new component. This behaviour is different to mithril's actual behaviour.

For each component node in the vdom tree, mithril-query calculates a `treePath` and saves it with a reference to that component's view. After redraws, any component node found with the same `treePath` as one previously calculated is drawn using the previously saved component view.

At the moment, the `treePath` for a component doesn't distinguish between differing components when they occur in the same point in the tree, meaning that mithril-query doesn't redraw these components after event triggers, etc.

It looks like this might have been a regression, as the renderComponent function used to be passed a treePath that included the node's key.
https://github.com/MithrilJS/mithril-query/commit/1666250c7360669b903bce7928814040b090781d#diff-168726dbe96b3ce427e7fedce31bb0bcL135