### PR TITLE
Bugfix/component instances becomes invalid for array children

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,21 +124,17 @@ function join(arrays) {
   }, [])
 }
 
-function renderComponents(states, instances, onremovers) {
+function renderComponents(states, onremovers) {
   function renderComponent(component, treePath) {
-    if (!instances[treePath]) {
-      if (isFunction(component.tag)) {
-        component.instance = component.tag(component)
-      } else if (isClass(component.tag)) {
-        const Component = component.tag
-        component.instance = new Component(component)
-      } else {
-        component.instance = copyObj(component.tag)
-      }
-      instances[treePath] = component.instance
+    if (isFunction(component.tag)) {
+      component.instance = component.tag(component)
+    } else if (isClass(component.tag)) {
+      const Component = component.tag
+      component.instance = new Component(component)
     } else {
-      component.instance = instances[treePath]
+      component.instance = copyObj(component.tag)
     }
+    
     if (!states[treePath]) {
       component.state = component.instance
       if (component.instance.oninit) {
@@ -200,9 +196,8 @@ function renderComponents(states, instances, onremovers) {
 
 function scan(render) {
   const states = {}
-  const instances = {}
   const onremovers = []
-  const renderNode = renderComponents(states, instances, onremovers)
+  const renderNode = renderComponents(states, onremovers)
   const api = {
     onremovers,
     redraw() {

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ const language = cssauron({
   },
   parent: 'parent',
   children(node) {
-    return isArray(node.renderedChildren)
+    return node && isArray(node.renderedChildren)
       ? node.renderedChildren.filter(identity)
       : []
   },
@@ -155,9 +155,7 @@ function renderComponents(states, onremovers) {
         component.instance.onupdate(component)
       }
     }
-    const node = component.instance.view(component)
-
-    return node
+    return component.instance.view(component)
   }
 
   return function renderNode(parent, node, treePath) {

--- a/test.js
+++ b/test.js
@@ -848,6 +848,28 @@ describe('components', function() {
       mq(m(nullComponent, m(myComponent))).should.not.have('aside.firstRender')
     })
   })
+
+  it('should not confuse component instance index on redraw', function () {
+    let showFirst = true;
+
+    const first = { view: () => m('div.first') }
+    const second = { view: () => m('div.second') }
+
+    var output = mq(m({
+      view: () => m('div', [
+        showFirst ? m(first) : m(second),
+      ]),
+    }));
+
+    output.should.have('div.first');
+    output.should.not.have('div.second');
+
+    showFirst = !showFirst;
+    output.redraw();
+
+    output.should.have('div.second');
+    output.should.not.have('div.first');
+  })
 })
 
 describe('Logging', function() {


### PR DESCRIPTION
Since version 2.4.0 this has been an issue that kept us from updating to the latest version. It was somewhat hard to pinpoint the issue at first but in the end a quite obvious problem.

When we keep track of instances and re-use them from their `treePath` it will pick and update the wrong component if they reside in a array.

I resolved this by going back on some changes but still maintaining the ES6 component support.