### PR TITLE
Support Babel-transpiled classes as components

### DIFF
--- a/fixtures/babel-class-component-with-destructuring.js
+++ b/fixtures/babel-class-component-with-destructuring.js
@@ -1,0 +1,29 @@
+"use strict";
+const m = require('mithril/hyperscript')
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default = function () { return _classCallCheck; };
+
+var BabelClassComponent = function () {
+  function BabelClassComponent(_ref) {
+    var model = _ref.attrs;
+
+    _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default()(this, BabelClassComponent);
+
+    this.model = model;
+  }
+
+  _createClass(BabelClassComponent, [{
+    key: 'view',
+    value: function view() {
+      return m('div', ['hello']);
+    }
+  }]);
+
+  return BabelClassComponent;
+}();
+
+module.exports = BabelClassComponent;

--- a/fixtures/babel-class-component.js
+++ b/fixtures/babel-class-component.js
@@ -1,0 +1,25 @@
+"use strict";
+const m = require('mithril/hyperscript')
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var BabelClassComponent = function () {
+  function BabelClassComponent(vnode) {
+    _classCallCheck(this, BabelClassComponent);
+
+    this.vnode = vnode;
+  }
+
+  _createClass(BabelClassComponent, [{
+    key: 'view',
+    value: function view() {
+      return m('div', ['hello']);
+    }
+  }]);
+
+  return BabelClassComponent;
+}();
+
+module.exports = BabelClassComponent;

--- a/fixtures/webpack-babel-transform-class-component-esmodules-with-destructuring.js
+++ b/fixtures/webpack-babel-transform-class-component-esmodules-with-destructuring.js
@@ -1,0 +1,29 @@
+"use strict";
+const m = require('mithril/hyperscript')
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = { default: _classCallCheck };
+
+var BabelClassComponent = function () {
+  function BabelClassComponent(_ref) {
+    var model = _ref.attrs;
+
+    Object(_babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__["default"])(this, BabelClassComponent);
+
+    this.model = model;
+  }
+
+  _createClass(BabelClassComponent, [{
+    key: 'view',
+    value: function view() {
+      return m('div', ['hello']);
+    }
+  }]);
+
+  return BabelClassComponent;
+}();
+
+module.exports = BabelClassComponent;

--- a/fixtures/webpack-babel-transform-class-component-esmodules.js
+++ b/fixtures/webpack-babel-transform-class-component-esmodules.js
@@ -1,0 +1,27 @@
+"use strict";
+const m = require('mithril/hyperscript')
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = { default: _classCallCheck };
+
+var BabelClassComponent = function () {
+  function BabelClassComponent(vnode) {
+    Object(_babel_runtime_helpers_esm_classCallCheck__WEBPACK_IMPORTED_MODULE_0__["default"])(this, BabelClassComponent);
+
+    this.vnode = vnode;
+  }
+
+  _createClass(BabelClassComponent, [{
+    key: 'view',
+    value: function view() {
+      return m('div', ['hello']);
+    }
+  }]);
+
+  return BabelClassComponent;
+}();
+
+module.exports = BabelClassComponent;

--- a/fixtures/webpack-babel-transform-class-component-with-destructuring.js
+++ b/fixtures/webpack-babel-transform-class-component-with-destructuring.js
@@ -1,0 +1,29 @@
+"use strict";
+const m = require('mithril/hyperscript')
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default = function () { return _classCallCheck; };
+
+var BabelClassComponent = function () {
+  function BabelClassComponent(_ref) {
+    var model = _ref.attrs;
+
+    _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default()(this, BabelClassComponent);
+
+    this.model = model;
+  }
+
+  _createClass(BabelClassComponent, [{
+    key: 'view',
+    value: function view() {
+      return m('div', ['hello']);
+    }
+  }]);
+
+  return BabelClassComponent;
+}();
+
+module.exports = BabelClassComponent;

--- a/fixtures/webpack-babel-transform-class-component.js
+++ b/fixtures/webpack-babel-transform-class-component.js
@@ -1,0 +1,27 @@
+"use strict";
+const m = require('mithril/hyperscript')
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default = function () { return _classCallCheck; };
+
+var BabelClassComponent = function () {
+  function BabelClassComponent(vnode) {
+    _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default()(this, BabelClassComponent);
+
+    this.vnode = vnode;
+  }
+
+  _createClass(BabelClassComponent, [{
+    key: 'view',
+    value: function view() {
+      return m('div', ['hello']);
+    }
+  }]);
+
+  return BabelClassComponent;
+}();
+
+module.exports = BabelClassComponent;

--- a/index.js
+++ b/index.js
@@ -66,7 +66,10 @@ function isFunction(thing) {
 }
 
 function isClass(thing) {
-  return typeof thing === 'function' && /^\s*class\s+/.test(thing.toString())
+  return typeof thing === 'function' && (
+    /^\s*class\s/.test(thing.toString()) || // ES6 class
+    /^\s*_classCallCheck\(/.test(thing.toString().replace(/^[^{]+{/, '')) // Babel class
+  )
 }
 
 function call(thing) {

--- a/index.js
+++ b/index.js
@@ -65,10 +65,22 @@ function isFunction(thing) {
   return typeof thing === 'function' && !isClass(thing)
 }
 
+function isBabelTranspiledClass(thing) {
+  const code = thing.toString().replace(/^[^{]+{/, '')
+
+  return (
+    // Regular Babel transpiled class
+    /(?:^|\s+)_classCallCheck\(/.test(code) ||
+    // Babel with @babel/transform-runtime and Webpack
+    /(?:^|\s+)_[^\s]+_classCallCheck__[^\s(]+\(/.test(code)
+  )
+}
+
+
 function isClass(thing) {
   return typeof thing === 'function' && (
     /^\s*class\s/.test(thing.toString()) || // ES6 class
-    /^\s*_classCallCheck\(/.test(thing.toString().replace(/^[^{]+{/, '')) // Babel class
+    isBabelTranspiledClass(thing) // Babel class
   )
 }
 

--- a/index.js
+++ b/index.js
@@ -72,7 +72,9 @@ function isBabelTranspiledClass(thing) {
     // Regular Babel transpiled class
     /(?:^|\s+)_classCallCheck\(/.test(code) ||
     // Babel with @babel/transform-runtime and Webpack
-    /(?:^|\s+)_[^\s]+_classCallCheck__[^\s(]+\(/.test(code)
+    /(?:^|\s+)_[^\s]+_classCallCheck__[^\s()]+\(/.test(code) ||
+    // Babel with @babel/transform-runtime (useESModules: true) and Webpack
+    /(?:^|\s+)Object\(_[^\s]+_classCallCheck__[^\s()]+\)\(/.test(code)
   )
 }
 

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ const mTrust = require('mithril/render/trust')
 const mq = require('./')
 const keyCode = require('yields-keycode')
 const expect = require('expect')
+const BabelClassComponent = require('./fixtures/babel-class-component')
 
 function noop() {}
 
@@ -676,6 +677,11 @@ describe('components', function() {
       }
       const out = mq(ES6Component)
       out.onremove()
+    })
+
+    it('should work with components transpiled with Babel', function() {
+      const out = mq(BabelClassComponent)
+      out.should.have('div:contains(hello)')
     })
   })
 

--- a/test.js
+++ b/test.js
@@ -7,6 +7,9 @@ const mq = require('./')
 const keyCode = require('yields-keycode')
 const expect = require('expect')
 const BabelClassComponent = require('./fixtures/babel-class-component')
+const BabelClassComponentWithDestructuring = require('./fixtures/babel-class-component-with-destructuring')
+const WebpackBabelClassComponent = require('./fixtures/webpack-babel-transform-class-component')
+const WebpackBabelClassComponentWithDestructuring = require('./fixtures/webpack-babel-transform-class-component-with-destructuring')
 
 function noop() {}
 
@@ -678,9 +681,26 @@ describe('components', function() {
       const out = mq(ES6Component)
       out.onremove()
     })
+  })
 
-    it('should work with components transpiled with Babel', function() {
+  describe('babel transpiled es6 class components', function() {
+    it('should work with simple components', function() {
       const out = mq(BabelClassComponent)
+      out.should.have('div:contains(hello)')
+    })
+
+    it('should work with components with destructured options', function() {
+      const out = mq(BabelClassComponentWithDestructuring)
+      out.should.have('div:contains(hello)')
+    })
+
+    it('should work with transformed components in Webpack', function() {
+      const out = mq(WebpackBabelClassComponent)
+      out.should.have('div:contains(hello)')
+    })
+
+    it('should work with transformed components with destructured options in Webpack', function() {
+      const out = mq(WebpackBabelClassComponentWithDestructuring)
       out.should.have('div:contains(hello)')
     })
   })

--- a/test.js
+++ b/test.js
@@ -10,6 +10,8 @@ const BabelClassComponent = require('./fixtures/babel-class-component')
 const BabelClassComponentWithDestructuring = require('./fixtures/babel-class-component-with-destructuring')
 const WebpackBabelClassComponent = require('./fixtures/webpack-babel-transform-class-component')
 const WebpackBabelClassComponentWithDestructuring = require('./fixtures/webpack-babel-transform-class-component-with-destructuring')
+const WebpackBabelClassEsComponent = require('./fixtures/webpack-babel-transform-class-component-esmodules')
+const WebpackBabelClassEsComponentWithDestructuring = require('./fixtures/webpack-babel-transform-class-component-esmodules-with-destructuring')
 
 function noop() {}
 
@@ -701,6 +703,16 @@ describe('components', function() {
 
     it('should work with transformed components with destructured options in Webpack', function() {
       const out = mq(WebpackBabelClassComponentWithDestructuring)
+      out.should.have('div:contains(hello)')
+    })
+
+    it('should work with transformed (useESModules) components in Webpack', function() {
+      const out = mq(WebpackBabelClassEsComponent)
+      out.should.have('div:contains(hello)')
+    })
+
+    it('should work with transformed (useESModules) components with destructured options in Webpack', function() {
+      const out = mq(WebpackBabelClassEsComponentWithDestructuring)
       out.should.have('div:contains(hello)')
     })
   })


### PR DESCRIPTION
## Motivation and Context

There is already a support for native ES6 `class`, but after Babel transpilation, we do not have `class` keyword, which will match it. Because of that, we fall into error - it's detected as function and called without `new` keyword (`TypeError: Cannot call a class as a function`).

Mithril handle them correctly, but `mithril-query` is unable to detect it.

## How Has This Been Tested?

I added unit tests for Babel components (similar to one in `mithril-node-render`). Also, I have run tests in real project, and these are passing now too.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read all applicable contributing documents.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the change log (if applicable).
