### PR TITLE
Added hook for oncreate

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,10 +169,11 @@ function renderComponents(states, onremovers) {
     }
 
     if (!states[treePath]) {
-      component.state = component.instance
       if (component.instance.oninit) {
         component.instance.oninit(component)
-        states[treePath] = component.state
+      }
+      if (component.instance.oncreate) {
+        component.instance.oncreate(component)
       }
       if (component.instance.onremove) {
         onremovers.push(function() {
@@ -183,12 +184,14 @@ function renderComponents(states, onremovers) {
         component.instance._captureVnode(component)
       }
     } else {
-      component.state = states[treePath]
+      component.instance = states[treePath]
       if (component.instance.onupdate) {
         component.instance.onupdate(component)
       }
     }
-    return component.instance.view(component)
+    const view = component.instance.view(component)
+    states[treePath] = component.instance
+    return view
   }
 
   return function renderNode(parent, node, treePath) {

--- a/index.js
+++ b/index.js
@@ -169,8 +169,11 @@ function renderComponents(states, onremovers) {
     }
 
     if (!states[treePath]) {
+      component.state = component.instance
+
       if (component.instance.oninit) {
         component.instance.oninit(component)
+        states[treePath] = component.state
       }
       if (component.instance.oncreate) {
         component.instance.oncreate(component)
@@ -183,15 +186,16 @@ function renderComponents(states, onremovers) {
       if (component.instance._captureVnode) {
         component.instance._captureVnode(component)
       }
+
     } else {
-      component.instance = states[treePath]
+      component.state = states[treePath]
+
       if (component.instance.onupdate) {
         component.instance.onupdate(component)
       }
     }
-    const view = component.instance.view(component)
-    states[treePath] = component.instance
-    return view
+
+    return component.instance.view(component)
   }
 
   return function renderNode(parent, node, treePath) {


### PR DESCRIPTION
## Description
Adding of oncreate` lifecycle methods to the state mutating part of `renderComponents`

## Motivation and Context
We're using `mithril-query` internally with Jest to do some simple unit testing of our components and pages/views.
I ran into some issues with a component that depended on the `onupdate` lifecycle method. Afterwards, me and a colleague spotted that there wasn't a hook for `oncreate`.

Adding the `oncreate` hook fixed all of our issues.

## How Has This Been Tested?
We ran our own tests to oversee the changes, and broke things with intent to see if the code still fails (or succeeds) when it should.

I also ran the test suite of the project, which passed all 89 tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read all applicable contributing documents.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the change log (if applicable).

I'll follow up on the above checklist as soon as I can, I just thought I'd at least submit the pull request!

Thank all of you for the mithril project and for your future help 🙏🏻 
