### PR TITLE
Cleanup types

### DIFF
--- a/mithril-query.d.ts
+++ b/mithril-query.d.ts
@@ -12,10 +12,10 @@ interface KeyEventOptions {
 interface MithrilQueryInstance {
   rootNode: any
   redraw: () => void
-  first: (selector: string) => any
+  first: (selector: string) => Element
   has: (selector: string) => boolean
   contains: (value: string) => string
-  find: (selector: string) => any[]
+  find: (selector: string) => Element[]
   setValue: (selector: string, value: string, silent?: boolean) => void
   focus: (selector: string, event?: Event, silent?: boolean) => void
   click: (selector: string, event?: Event, silent?: boolean) => void
@@ -43,9 +43,7 @@ interface MithrilQueryInstance {
     }
     have: {
       (expectedCount: number, selector: string): boolean
-      (selector: string): boolean
-      (selectors: string[]): boolean
-
+      (selector: string | string[]): boolean
       at: {
         least: (minCount: number, selector: string) => boolean
       }


### PR DESCRIPTION
Change any into Element types so they can be used safely in tests, combine line 46 into a union type.

## Description
While using mithril-query, I forked the types to make them more strict.  I believe the `any`s could be replaced with a generic `Element` type .

## Motivation and Context
More strict types, better autocomplete

## How Has This Been Tested?
I have been using a custom .d.ts file with these changes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read all applicable contributing documents.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the change log (if applicable).
