### PR TITLE
Add support for children

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,13 +242,15 @@ function scan(api) {
   return api
 }
 
-module.exports = function init(componentOrRootNode, nodeOrAttrs) {
+module.exports = function init(componentOrRootNode, nodeOrAttrs, children) {
   const $window = global.window = domino.createWindow('')
   const render = require('mithril/render/render')($window)
   let rootNode = {
     view: () => {
       return isComponent(componentOrRootNode)
-        ? m(componentOrRootNode, nodeOrAttrs)
+        ? m(componentOrRootNode, nodeOrAttrs, children === undefined ?
+           [] :
+           children)
         : componentOrRootNode
     },
   }


### PR DESCRIPTION
Allow children to be passed to `mq`

## Description
This change lets you pass children to mq, i.e. `mq(MyComponent, attrs, m(MyOtherComponent)`

## Motivation and Context
#117 

## How Has This Been Tested?
I am using this code in my testing currently

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read all applicable contributing documents.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the change log (if applicable).
